### PR TITLE
Update docker build workflow with more efficient one

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -35,7 +35,11 @@ jobs:
 
       # Comment this if you prefer to use the docker.io image repository | This method can be better because it didn't need any password (use the credentials of the people who commit)
       - name: Docker login to GitHub
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare available platforms build
         env: # Here you need to test on what platform your docker image can be build. Important one is linux/arm/v7, linux/arm64 and linux/amd64

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -65,10 +65,28 @@ jobs:
           
           # Save Available platforms
           echo "available_platforms=${available_platforms}" >> $GITHUB_ENV
+      # Use cache image for quicker build time.
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # Use official buildx GitHub Action
       - name: Docker build & push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms:  ${{ env.available_platforms }}
+          tags: ghcr.io/${{ github.repository }}:latest
+
+      # Save new cache
+      - name: Move cache
         run: |
-          docker buildx build \
-          --output type=image,push=true \
-          --platform ${{ env.available_platforms }} \
-          --tag ghcr.io/${{ github.repository }}:latest \
-          .
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -2,7 +2,7 @@ name: Build docker images
 
 on:
   push:
-  pull_request:
+    branches: [ 'master' ]
   schedule:
     # Cron execution is for weekly dependencies update (for security update)
     #             ┌───────────── minute (0 - 59)
@@ -16,76 +16,55 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - amd64
-          - arm64
-          - arm/v7
-          - 386
     steps:
       - name: Checkout code from Git repository
         uses: actions/checkout@v2
 
-      - id: buildx
-        name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
-        with:
-          buildx-version: latest
-          qemu-version: latest
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # Only if you want the image to be push to docker.io instead of the GitHub Package repository
+#       - name: Docker login to DockerHub
+#         uses: docker/login-action@v1
+#         with:
+#           username: ${{ secrets.DOCKER_USERNAME }}
+#           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build & Push
+      # Comment this if you prefer to use the docker.io image repository | This method can be better because it didn't need any password (use the credentials of the people who commit)
+      - name: Docker login to GitHub
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Prepare available platforms build
+        env: # Here you need to test on what platform your docker image can be build. Important one is linux/arm/v7, linux/arm64 and linux/amd64
+          requested_platforms: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6"
         run: |
-          IMAGE_ID=billzimmerman/raspap
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo ${VERSION} | sed -e 's/^v//')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-          if [ -n "${{ matrix.platform }}" ]; then
-            _platform=${{ matrix.platform }}
-            VERSION="${VERSION}-${_platform//\/}"
+          # If you use the `requested_platforms` env var, then parse it.
+          if [ -z "${requested_platforms}" ]; then
+            # Transform env var into bash array to calculate arrays intersect. That allow us to know the plateform that can work with our image who can be build on current github docker buildx.
+            IFS=',' read -r -a requested_platforms <<< "${requested_platforms}"
+            IFS=',' read -r -a available_platforms <<< "${{ steps.buildx.outputs.platforms }}"
+            # Only got the intersect of two arrays
+            available_platforms=$(comm -12 <(printf '%s\n' "${requested_platforms[@]}" | LC_ALL=C sort) <(printf '%s\n' "${available_platforms[@]}" | LC_ALL=C sort))
+            # Just format the output for the docker commands
+            requested_platforms="${requested_platforms//'
+          '/,}"
+            available_platforms="${available_platforms//'
+          '/,}"
+          else
+            available_platforms="${{ steps.buildx.outputs.platforms }}"
           fi
-          echo "IMAGE_ID=${IMAGE_ID}"
-          echo "VERSION=${VERSION}"
 
+          echo "available_platforms=$available_platforms"
+          
+          # Save Available platforms
+          echo "available_platforms=${available_platforms}" >> $GITHUB_ENV
+      - name: Docker build & push
+        run: |
           docker buildx build \
-            --platform linux/${{ matrix.platform }} \
-            --tag ${IMAGE_ID}:${VERSION} \
-            --file ./Dockerfile \
-            --output type=image,push=true .
-
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      DOCKER_CLI_EXPERIMENTAL: enabled
-    steps:
-      - name: Get current branch
-        run: |
-          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
-          if [ "${BRANCH_NAME}" = "master" ]; then
-            BRANCH_NAME="latest"
-          fi
-          echo "::set-env name=BRANCH_NAME::${BRANCH_NAME}"
-      - run: |
-          IMAGE_ID=billzimmerman/raspap
-                  
-          docker manifest create ${IMAGE_ID}:${{ env.BRANCH_NAME }} \
-                                 ${IMAGE_ID}:${{ env.BRANCH_NAME }}-amd64 \
-                                 ${IMAGE_ID}:${{ env.BRANCH_NAME }}-arm64 \
-                                 ${IMAGE_ID}:${{ env.BRANCH_NAME }}-armv7 \
-                                 ${IMAGE_ID}:${{ env.BRANCH_NAME }}-386
-
-          docker manifest push ${IMAGE_ID}:${{ env.BRANCH_NAME }}
+          --output type=image,push=true \
+          --platform ${{ env.available_platforms }} \
+          --tag ghcr.io/${{ github.repository }}:latest \
+          .


### PR DESCRIPTION
This is a better option than the one I've send to you some month ago.
This one is a lot quicker and didn't need to create a tag for each platforms you want to support.
That also allow you to not send your docker password and that remove a lot of custom and not maintained GitHub Action and replace it with official GitHub one.