### PR TITLE
feat(v2): supervisord controlled container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+raspap-ansible
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
-FROM alehaa/debian-systemd:buster
-RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
-COPY setup.sh .
+#FROM balenalib/raspberrypi3:bullseye-20220415
+FROM balenalib/raspberrypi3:buster-20220415
+WORKDIR /app
+RUN install_packages ansible git supervisor
+RUN git clone https://github.com/RaspAP/raspap-ansible
+# do this in ansible step instead long-term
+#RUN install_packages lighttpd git hostapd dnsmasq iptables-persistent vnstat qrencode php7.3-cgi openvpn wpasupplicant
+#RUN install_packages iw wireless-tools vim dhcpcd5
+#RUN mkdir -p /var/run/lighttpd && chmod 777 /var/run/lighttpd
+#COPY raspap-ansible /app/
+RUN ansible-playbook docker.yaml --connection=local
+COPY supervisord.conf wpa_supplicant.conf /app/
+ENTRYPOINT ["/usr/bin/supervisord","-n","-c","/app/supervisord.conf"]
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-curl -sL https://install.raspap.com | bash

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,39 @@
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisord]
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[program:lighttpd]
+command=/usr/sbin/lighttpd -D -f /etc/lighttpd/lighttpd.conf
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+[program:wpa]
+command=/sbin/wpa_supplicant -i wlan0 -c /app/wpa_supplicant.conf -d -O /run/wpa_supplicant
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+[program:raspapd]
+command=/bin/bash /etc/raspap/hostapd/servicestart.sh --interface br0 --seconds 3
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+[program:hostapd]
+environment=DAEMON_CONF="/etc/hostapd/hostapd.conf"
+command=/bin/bash -c 'source /etc/default/hostapd && /usr/sbin/hostapd -f /tmp/hostapd.log -P /run/hostapd.pid $DAEMON_OPTS ${DAEMON_CONF}'
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+[program:dnsmasq]
+command=/usr/sbin/dnsmasq -k -x /run/dnsmasq/dnsmasq.pid -r /run/dnsmasq/resolv.conf -7 /etc/dnsmasq.d
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
+;[program:dhcpcd]
+;command=/sbin/dhcpcd -B -d
+;stdout_logfile=/dev/fd/1
+;stdout_logfile_maxbytes=0
+

--- a/wpa_supplicant.conf
+++ b/wpa_supplicant.conf
@@ -1,0 +1,4 @@
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+country=US
+


### PR DESCRIPTION
This change makes raspap-docker use supervisord instead of systemd.
The current version is tested to be functional with "out of the box connectivity".
More work is needed to support process restarts from config changes (possibly in raspap-webgui).
The docker container uses the raspap-ansible repo with a slightly modified playbook.
There are a few more outstanding issues that need addressed:

1. dhcpcd is not playing nicely inside the container. To get a static ip on wlan0 I had to put the RaspAP config outside of the container on the host's dhcpcd.
2. iptable rules need to be handled at 'docker run' time, not at docker build time (where they are excluded)
3. Configuration should be able to persist if a new version of the raspap docker image comes out. Basically let's support volume mounts
4. A good way to depend on raspap-ansible. Is a submodule overkill? Good enough to git clone inside the docker build?

This PR is a work-in-progress.