### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alehaa/debian-systemd:buster
+FROM jrei/systemd-debian:10
 RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
 COPY setup.sh .


### PR DESCRIPTION
The previous container `alehaa/debian-systemd` that was used in previous builds does not exist on Docker Hub anymore. This pull request updates the base image in the Dockerfile with another image having the same functionality. The Debian release remains Debian Buster.