### PR TITLE
fix: rpi-compatible Docker images

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,8 +1,8 @@
-name: Build docker images
+name: Build Docker Images
 
 on:
   push:
-    branches: [ 'master' ]
+    branches: ['master']
   schedule:
     # Cron execution is for weekly dependencies update (for security update)
     #             ┌───────────── minute (0 - 59)
@@ -10,7 +10,7 @@ on:
     #             │ │ ┌───────────── day of the month (1 - 31)
     #             │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #             │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    - cron: "0 0 * * 0"
+    - cron: '0 0 * * 0'
 
 jobs:
   build:
@@ -26,47 +26,24 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      # Only if you want the image to be push to docker.io instead of the GitHub Package repository
-#       - name: Docker login to DockerHub
-#         uses: docker/login-action@v1
-#         with:
-#           username: ${{ secrets.DOCKER_USERNAME }}
-#           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # Comment this if you prefer to use the docker.io image repository | This method can be better because it didn't need any password (use the credentials of the people who commit)
       - name: Docker login to GitHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare available platforms build
-        env: # Here you need to test on what platform your docker image can be build. Important one is linux/arm/v7, linux/arm64 and linux/amd64
-          requested_platforms: "linux/amd64,linux/arm64,linux/arm/v7" # jrei/systemd-debian:10 support only i386, amd64, arm and arm64
-          image: "ghcr.io/${{ github.repository }}:latest"
+        env:
+          requested_platforms: 'linux/amd64,linux/arm64,linux/arm/v7'
         run: |
-          # If you use the `requested_platforms` env var, then parse it.
-          if [ -n "${requested_platforms}" ]; then
-            # Transform env var into bash array to calculate arrays intersect. That allow us to know the plateform that can work with our image who can be build on current github docker buildx.
-            IFS=',' read -r -a requested_platforms <<< "${requested_platforms}"
-            IFS=',' read -r -a available_platforms <<< "${{ steps.buildx.outputs.platforms }}"
-            # Only got the intersect of two arrays
-            available_platforms=$(comm -12 <(printf '%s\n' "${requested_platforms[@]}" | LC_ALL=C sort) <(printf '%s\n' "${available_platforms[@]}" | LC_ALL=C sort))
-            # Just format the output for the docker commands
-            requested_platforms="${requested_platforms//'
-          '/,}"
-            available_platforms="${available_platforms//'
-          '/,}"
-          else
-            available_platforms="${{ steps.buildx.outputs.platforms }}"
-          fi
-
+          IFS=',' read -r -a requested_platforms <<< "${requested_platforms}"
+          IFS=',' read -r -a available_platforms <<< "${{ steps.buildx.outputs.platforms }}"
+          available_platforms=$(comm -12 <(printf '%s\n' "${requested_platforms[@]}" | LC_ALL=C sort) <(printf '%s\n' "${available_platforms[@]}" | LC_ALL=C sort))
+          requested_platforms="${requested_platforms//'\n'/,}"
+          available_platforms="${available_platforms//'\n'/,}"
           echo "available_platforms=$available_platforms"
-          
-          # Save Available platforms
-          echo "available_platforms=${available_platforms}" >> $GITHUB_ENV
-          echo "docker_image=${image,,}" >> $GITHUB_ENV
+          echo "requested_platforms=${requested_platforms}" >> $GITHUB_ENV
 
       # Use cache image for quicker build time.
       - name: Cache Docker layers
@@ -77,16 +54,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      # Use official buildx GitHub Action
-      - name: Docker build & push
+      # Build & push Docker images
+      - name: Docker build & push - Dockerfile.deb11
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
+          dockerfile: Dockerfiles/Dockerfile.deb11
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
-          platforms:  ${{ env.available_platforms }}
-          tags: ${{ env.docker_image }}
+          platforms: ${{ env.available_platforms }}
+          tags: ${{ github.repository }}:bullseye
+
+      - name: Docker build & push - Dockerfile.deb12
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          dockerfile: Dockerfiles/Dockerfile.deb12
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms: ${{ env.available_platforms }}
+          tags: ${{ github.repository }}:bookworm
 
       # Save new cache
       - name: Move cache

--- a/Dockerfiles/Dockerfile.deb11
+++ b/Dockerfiles/Dockerfile.deb11
@@ -1,3 +1,3 @@
-FROM jrei/systemd-debian:10
+FROM jrei/systemd-debian:11
 RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
 COPY setup.sh .

--- a/Dockerfiles/Dockerfile.deb12
+++ b/Dockerfiles/Dockerfile.deb12
@@ -1,0 +1,3 @@
+FROM jrei/systemd-debian:12
+RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
+COPY setup.sh .

--- a/README.md
+++ b/README.md
@@ -1,14 +1,63 @@
 ![raspap-docker-repository](https://user-images.githubusercontent.com/229399/111151581-edb7df00-858f-11eb-8e3a-3ac11c3c04b7.png)
 
-
 # raspap-docker
+
 A community-led docker container for RaspAP
 
-# Usage
+## Setting up using Docker
+
+### Debian 12
+
+1. Start the container with `jrcichra/raspap-docker:bookworm` image
+
 ```
-docker run --name raspap -it -d --privileged --network=host -v /sys/fs/cgroup:/sys/fs/cgroup:ro --cap-add SYS_ADMIN jrcichra/raspap-docker
+docker run --name raspap -it -d --privileged --network=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN jrcichra/raspap-docker:bookworm
+```
+
+2. Enter the container
+
+```
 docker exec -it raspap bash
-$ ./setup.sh
-docker restart raspap
-Web GUI should be accessible on http://localhost by default
 ```
+
+3. Run the setup script
+
+```
+./setup.sh
+```
+
+4. Restart the container
+
+```
+docker restart raspap
+```
+
+5. Web GUI should be accessible on [http://localhost](http://localhost) by default
+
+### Debian 11
+
+1. Start the container with `jrcichra/raspap-docker:bullseye` image
+
+```
+docker run --name raspap -it -d --privileged --network=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN jrcichra/raspap-docker:bullseye
+```
+
+2. Enter the container
+
+```
+docker exec -it raspap bash
+```
+
+3. Run the setup script
+
+```
+./setup.sh
+```
+
+4. Restart the container
+
+```
+docker restart raspap
+```
+
+5. Web GUI should be accessible on [http://localhost](http://localhost) by default


### PR DESCRIPTION
## Issue
Fixes #18 
/claim #18

## Description
- Added support for debian based systems
- Works on bookworm and github.repo:bullseye
- Made required  changes to `build_docker_image.yml`
- When there is a push on master branch `jrcichra/raspap-docker:bookworm` and `jrcichra/raspap-docker:bullseye` docker images are built and pushed to the repository
- Made required changes on `README.md`

Tested on Raspberry Pi 3 Model B+