### PR TITLE
fix for arm devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A community-led docker container for RaspAP
 
 # Usage
 ```
-docker run --name raspap -it -d --privileged --network=host -v /sys/fs/cgroup:/sys/fs/cgroup:ro --cap-add SYS_ADMIN jrcichra/raspap-docker
+docker run --name raspap -it -d --privileged --network=host -v /sys/fs/cgroup:/sys/fs/cgroup:ro --cap-add SYS_ADMIN ghcr.io/raspap/raspap-docker:latest
 docker exec -it raspap bash
 $ ./setup.sh
 docker restart raspap
@@ -15,14 +15,14 @@ Web GUI should be accessible on http://localhost by default
 ## Workaround for arm devices
 To use this container on arm devices you have to make cgroups writable:
 ```
-docker run --name raspap -it -d --privileged --network=host --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN jrcichra/raspap-docker
+docker run --name raspap -it -d --privileged --network=host --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN ghcr.io/raspap/raspap-docker:latest
 docker exec -it raspap bash
 $ ./setup.sh
 docker restart raspap
 Web GUI should be accessible on http://localhost by default
 ```
 ## Allow WiFi-clients to connect to LAN and internet
-Because of docker isolation and security defaults the following rules must be added on the docker host:
+Because of docker isolation and security defaults the following rules must be added in the docker container:
 ```
 iptables -I DOCKER-USER -i src_if -o dst_if -j ACCEPT
 iptables -t nat -C POSTROUTING -o eth0 -j MASQUERADE || iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE


### PR DESCRIPTION
Hi y'all,

this is an easy fix for ARM devices as issued in #18 
There is a current bug in docker cgroups, so a permanent fix is not possible from my side, there is however a workaround.
The workaround is to mount cgroups as host and make them writable. (--cgroupns host) (-v /sys/fs/cgroup:/sys/fs/cgroup:rw )
The readme is updated with an extra section, and no code changes are needed.

Gr. TCH

/claim 18