### PR TITLE
Refactor dockerfile for easy setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM jrei/systemd-debian:12
 RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
 RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1
+COPY firewall-rules.sh /home/firewall-rules.sh
+RUN chmod +x /home/firewall-rules.sh
+CMD /home/firewall-rules.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM jrei/systemd-debian:10
+FROM ghcr.io/raspap/raspap-docker
 RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
-COPY setup.sh .
+RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/raspap/raspap-docker
+FROM jrei/systemd-debian:12
 RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
 RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1

--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ $ ./setup.sh
 docker restart raspap
 Web GUI should be accessible on http://localhost by default
 ```
+## Workaround for arm devices
+To use this container on arm devices you have to make cgroups writable:
+```
+docker run --name raspap -it -d --privileged --network=host --cgroupns host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN jrcichra/raspap-docker
+docker exec -it raspap bash
+$ ./setup.sh
+docker restart raspap
+Web GUI should be accessible on http://localhost by default
+```

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ $ ./setup.sh
 docker restart raspap
 Web GUI should be accessible on http://localhost by default
 ```
+## Allow WiFi-clients to connect to LAN and internet
+Because of docker isolation and security defaults the following rules must be added on the docker host:
+```
+iptables -I DOCKER-USER -i src_if -o dst_if -j ACCEPT
+iptables -t nat -C POSTROUTING -o eth0 -j MASQUERADE || iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+iptables -C FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT || iptables -A FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+iptables -C FORWARD -i wlan0 -o eth0 -j ACCEPT || iptables -A FORWARD -i wlan0 -o eth0 -j ACCEPT
+iptables-save
+```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Web GUI should be accessible on http://localhost by default
 ## Workaround for arm devices
 To use this container on arm devices you have to make cgroups writable:
 ```
-docker run --name raspap -it -d --privileged --network=host --cgroupns host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN jrcichra/raspap-docker
+docker run --name raspap -it -d --privileged --network=host --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN jrcichra/raspap-docker
 docker exec -it raspap bash
 $ ./setup.sh
 docker restart raspap

--- a/README.md
+++ b/README.md
@@ -7,18 +7,12 @@ A community-led docker container for RaspAP
 # Usage
 ```
 docker run --name raspap -it -d --privileged --network=host -v /sys/fs/cgroup:/sys/fs/cgroup:ro --cap-add SYS_ADMIN jrcichra/raspap-docker
-docker exec -it raspap bash
-$ ./setup.sh
-docker restart raspap
 Web GUI should be accessible on http://localhost by default
 ```
 ## Workaround for arm devices
 To use this container on arm devices you have to make cgroups writable:
 ```
 docker run --name raspap -it -d --privileged --network=host --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cap-add SYS_ADMIN jrcichra/raspap-docker
-docker exec -it raspap bash
-$ ./setup.sh
-docker restart raspap
 Web GUI should be accessible on http://localhost by default
 ```
 ## Allow WiFi-clients to connect to LAN and internet

--- a/firewall-rules.sh
+++ b/firewall-rules.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+iptables -I DOCKER-USER -i src_if -o dst_if -j ACCEPT
+iptables -t nat -C POSTROUTING -o eth0 -j MASQUERADE || iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+iptables -C FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT || iptables -A FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+iptables -C FORWARD -i wlan0 -o eth0 -j ACCEPT || iptables -A FORWARD -i wlan0 -o eth0 -j ACCEPT
+iptables-save

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-curl -sL https://install.raspap.com | bash


### PR DESCRIPTION
Hey, with this updated dockerfile there are no manual steps involved anymore.
Now after running the container raspap is already installed with all features (wireguard,openvpn,adblock) installed.
No manual setup to be run + no manual reboot to be done 

This because if for example openvpn is not needed, there is no harm in having it installed :)