### PR TITLE
Bump debian release version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM jrei/systemd-debian:10
+FROM jrei/systemd-debian:12
 RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
 COPY setup.sh .


### PR DESCRIPTION
Per convo [here](https://github.com/RaspAP/raspap-docker/pull/21/files#r1439637180). See also https://github.com/RaspAP/raspap-docker/pull/20#issuecomment-1879662560. With the existing workflow this should build to `ghcr.io/raspap/raspap-docker`. If not, feel free to update as needed. 