### PR TITLE
fix container run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/li
 RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1
 COPY firewall-rules.sh /home/firewall-rules.sh
 RUN chmod +x /home/firewall-rules.sh
-CMD /home/firewall-rules.sh
+CMD [ "/bin/bash", "-c", "/home/firewall-rules.sh && tail -f /dev/null" ]


### PR DESCRIPTION
this is extremly ugly, but the container exists when the script is ran, so after running the script we will tail /dev/null this will never stop so the container will never stop. again, super ugly, but i don't know a better way. maybe @jrcichra knows a cleaner method