### PR TITLE
Add required iproute2 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openv
 COPY firewall-rules.sh /home/firewall-rules.sh
 RUN chmod +x /home/firewall-rules.sh
 CMD [ "/bin/bash", "-c", "/home/firewall-rules.sh && /lib/systemd/systemd" ]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openv
 COPY firewall-rules.sh /home/firewall-rules.sh
 RUN chmod +x /home/firewall-rules.sh
 CMD [ "/bin/bash", "-c", "/home/firewall-rules.sh && /lib/systemd/systemd" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM jrei/systemd-debian:12
-RUN apt update && apt install -y sudo wget procps curl systemd && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y sudo wget procps curl systemd iproute2 && rm -rf /var/lib/apt/lists/*
 RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1
 COPY firewall-rules.sh /home/firewall-rules.sh
 RUN chmod +x /home/firewall-rules.sh


### PR DESCRIPTION
The `ip` utility is provided by this package and used by RaspAP to enumerate available network interfaces.