### PR TITLE
Add wpa_supplicant.conf to project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM jrei/systemd-debian:12
 RUN apt update && apt install -y sudo wget procps curl systemd iproute2 && rm -rf /var/lib/apt/lists/*
 RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1
 COPY firewall-rules.sh /home/firewall-rules.sh
+COPY wpa_supplicant.conf /etc/wpa_supplicant/
 RUN chmod +x /home/firewall-rules.sh
 CMD [ "/bin/bash", "-c", "/home/firewall-rules.sh && /lib/systemd/systemd" ]

--- a/wpa_supplicant.conf
+++ b/wpa_supplicant.conf
@@ -1,0 +1,2 @@
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1


### PR DESCRIPTION
Note: ~without restarting the container~ wpa_supplicant needs to be explicitly reinitialized. This can be done from the WiFi client UI. In testing, the action tied to the button needs to be updated from:

```
wpa_cli -i $iface reconfigure
```
to...
```
wpa_supplicant -i $iface -D wext -c/etc/wpa_supplicant/wpa_supplicant.conf -B
```
~Alternative to requiring a UI action would be to restart the container.~
Restarting the container does not reinitialize wpa_supplicant.

Build process output:
```
docker build . -t raspap
...
Removing intermediate container 63be8890ba9f
 ---> b01451da7dc4
Step 4/7 : COPY firewall-rules.sh /home/firewall-rules.sh
 ---> b2eaed0372d6
Step 5/7 : COPY wpa_supplicant.conf /etc/wpa_supplicant/
 ---> e86543357788
Step 6/7 : RUN chmod +x /home/firewall-rules.sh
 ---> Running in c2b4cba58b3c
Removing intermediate container c2b4cba58b3c
 ---> fa33d5c50c46
Step 7/7 : CMD [ "/bin/bash", "-c", "/home/firewall-rules.sh && /lib/systemd/systemd" ]
 ---> Running in 3f5bb36deb49
Removing intermediate container 3f5bb36deb49
 ---> 7fccd7707034
Successfully built 7fccd7707034
Successfully tagged raspap:latest
```
Resolves #5 

