### PR TITLE
why cgroup?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /lib/systemd/system/plymouth* \
     /lib/systemd/system/systemd-update-utmp*
 
-VOLUME [ "/sys/fs/cgroup" ]
-
 RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1
 COPY firewall-rules.sh /home/firewall-rules.sh
 COPY wpa_supplicant.conf /etc/wpa_supplicant/


### PR DESCRIPTION
if we remove this line, and run the container using the following command:
`docker run --name raspap -it -d --privileged --network=host --cap-add SYS_ADMIN <imagename>`
there is no command or code relating to cgroups and the container starts + hostapd is running.

in this way the container runs with the same command on ARM64 and X86

or do we need cgroup?
