### PR TITLE
Environment Variables For Configuration 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,8 @@ RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openv
 COPY firewall-rules.sh /home/firewall-rules.sh
 COPY wpa_supplicant.conf /etc/wpa_supplicant/
 RUN chmod +x /home/firewall-rules.sh
-CMD [ "/bin/bash", "-c", "/home/firewall-rules.sh && /lib/systemd/systemd" ]
+COPY env-setup.sh /home/env-setup.sh
+RUN chmod +x /home/env-setup.sh
+COPY password-generator.php /home/password-generator.php
+
+CMD [ "/bin/bash", "-c", "/home/env-setup.sh && /home/firewall-rules.sh && /lib/systemd/systemd" ]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Several environment variables are made available in this docker image to aid in 
 | RASPAP_SSID_PASS       | The SSID password                                | ChangeMe      |
 | RASPAP_COUNTRY         | The SSID country code                            | GB            |
 | RASPAP_WEBGUI_USER     | The admin username for the RaspAP user interface | admin         |
-| RASPAP_WEBGUI_PASSWORD | The admin password for the RaspAP user interface | secret        |
+| RASPAP_WEBGUI_PASS     | The admin password for the RaspAP user interface | secret        |
 | RASPAP_WEBGUI_PORT     | The RaspAP web user interface port               | 80            |
 
 Some further configuration is also possible through the use of the following prefixed environment variables, in the form RASAPAP_\[target]_\[key]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,25 @@ git clone https://github.com/RaspAP/raspap-docker.git
 cd raspap-docker
 docker compose up -d
 ```
+
+## Environment Variables
+Several environment variables are made available in this docker image to aid in configuration.
+
+| Environment Variable   | Description                                      | Default       |
+|------------------------|--------------------------------------------------|---------------|
+| RASPAP_SSID            | The SSID name                                    | raspap-webgui |
+| RASPAP_SSID_PASS       | The SSID password                                | ChangeMe      |
+| RASPAP_COUNTRY         | The SSID country code                            | GB            |
+| RASPAP_WEBGUI_USER     | The admin username for the RaspAP user interface | admin         |
+| RASPAP_WEBGUI_PASSWORD | The admin password for the RaspAP user interface | secret        |
+| RASPAP_WEBGUI_PORT     | The RaspAP web user interface port               | 80            |
+
+Some further configuration is also possible through the use of the following prefixed environment variables, in the form RASAPAP_\[target]_\[key]
+
+| Environment Variable Prefix | Target File                    |
+|-----------------------------|--------------------------------|
+| RASPAP_hostapd_             | /etc/hostapd/hostapd.conf      |
+| RASPAP_raspap_              | /etc/dnsmasq.d/090_raspap.conf |
+| RASPAP_wlan0_               | /etc/dnsmasq.d/090_wlan0.conf  |
+
+For example, `RASPAP_hostapd_driver` would set the `driver` value in `/etc/hostapd/hostapd.conf`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - RASPAP_SSID_PASS=ChangeMe
       - RASPAP_COUNTRY=GB
       - RASPAP_WEBGUI_USER=admin
-      - RASPAP_WEBGUI_PASSWORD=secret
+      - RASPAP_WEBGUI_PASS=secret
       - RASPAP_WEBGUI_PORT=80
     cap_add:
       - SYS_ADMIN

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,13 @@ services:
     privileged: true
     network_mode: host
     #cgroup: host # uncomment when using an ARM device 
+    environment:
+      - RASPAP_SSID=raspap-webgui
+      - RASPAP_SSID_PASS=ChangeMe
+      - RASPAP_COUNTRY=GB
+      - RASPAP_WEBGUI_USER=admin
+      - RASPAP_WEBGUI_PASSWORD=secret
+      - RASPAP_WEBGUI_PORT=80
     cap_add:
       - SYS_ADMIN
     volumes:

--- a/env-setup.sh
+++ b/env-setup.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+declare -A aliases=(
+    [RASPAP_SSID]=RASPAP_hostapd_ssid
+    [RASPAP_SSID_PASS]=RASPAP_hostapd_wpa_passphrase
+)
+
+# Files that follow a predictable key=value format
+declare -A conf_files=(
+    [raspap]=/etc/dnsmasq.d/090_raspap.conf
+    [wlan0]=/etc/dnsmasq.d/090_wlan0.conf
+    [hostapd]=/etc/hostapd/hostapd.conf
+)
+
+raspap_auth=/etc/raspap/raspap.auth
+lighttpd_conf=/etc/lighttpd/lighttpd.conf
+
+function main() {
+    alias_env_vars
+    update_webgui_auth $RASPAP_WEBGUI_USER $RASPAP_WEBGUI_PASS
+    update_webgui_port $RASPAP_WEBGUI_PORT
+    update_confs
+}
+
+function alias_env_vars() {
+    for alias in "${!aliases[@]}"
+    do
+        if [ ! -z "${!alias}" ]
+        then
+            declare -g ${aliases[$alias]}="${!alias}"
+            export ${aliases[$alias]}
+        fi
+    done
+}
+
+# $1 - Username
+# $2 - Password
+function update_webgui_auth() {
+    declare user=$1
+    declare pass=$2
+    if [ -z $user ]
+    then
+        # If not set, keep existing value
+        user=$(head $raspap_auth -n+1)
+    fi
+
+    if [ -z "${pass}" ]
+    then
+        # If not set, keep existing value
+        pass=$(tail $raspap_auth -n+2)
+    else
+        # Hash password
+        pass=$(php /home/password-generator.php ${pass})
+    fi
+
+    echo "$user" > "$raspap_auth"
+    echo "$pass" >> "$raspap_auth"
+}
+
+# $1 - Port
+function update_webgui_port() {
+    port=$1
+    if [ ! -z "${!port}" ]
+    then
+        # Only update if env var is set
+        return
+    fi
+    old="server.port                 = 80"
+    new="server.port                 = ${port}"
+    sudo sed -i "s/$old/$new/g" ${lighttpd_conf}
+}
+
+update_confs() {
+    for conf in "${!conf_files[@]}"
+    do
+        path=${conf_files[$conf]}
+        prefix=RASPAP_${conf}_
+        vars=$(get_prefixed_env_vars ${prefix})
+        for var in ${vars}
+        do
+            key=${var#"$prefix"}
+            replace_in_conf $key ${!var} $path
+        done
+    done
+}
+
+# $1 - Prefix
+function get_prefixed_env_vars() {
+    prefix=$1
+    matches=$(printenv | grep -o "${prefix}[^=]*")
+    echo $matches
+}
+
+# $1 - Target key
+# $2 - New value
+# $3 - conf path
+function replace_in_conf() {
+    key=$1
+    val=$2
+    path=$3
+
+    old="$key"=".*"
+    new="$key"="$val"
+
+    if [ -z "$(grep "$old" $path)" ]
+    then
+        # Add value
+        echo $new >> $path
+    else
+        # Value exists in conf
+        sudo sed -i "s/$old/$new/g" $path
+    fi
+}
+
+main

--- a/env-setup.sh
+++ b/env-setup.sh
@@ -65,7 +65,7 @@ function update_webgui_port() {
         # Only update if env var is set
         return
     fi
-    old="server.port                 = 80$"
+    old="server.port                 = [0-9]*"
     new="server.port                 = ${port}"
     sudo sed -i "s/$old/$new/g" ${lighttpd_conf}
 }

--- a/env-setup.sh
+++ b/env-setup.sh
@@ -65,7 +65,7 @@ function update_webgui_port() {
         # Only update if env var is set
         return
     fi
-    old="server.port                 = 80"
+    old="server.port                 = 80$"
     new="server.port                 = ${port}"
     sudo sed -i "s/$old/$new/g" ${lighttpd_conf}
 }

--- a/env-setup.sh
+++ b/env-setup.sh
@@ -2,6 +2,7 @@
 declare -A aliases=(
     [RASPAP_SSID]=RASPAP_hostapd_ssid
     [RASPAP_SSID_PASS]=RASPAP_hostapd_wpa_passphrase
+    [RASPAP_COUNTRY]=RASPAP_hostapd_country_code
 )
 
 # Files that follow a predictable key=value format

--- a/password-generator.php
+++ b/password-generator.php
@@ -1,0 +1,3 @@
+<?php
+echo password_hash($argv[1], PASSWORD_BCRYPT);
+?>


### PR DESCRIPTION
### Issue

Implements #30 

### Description

- Added two files, `env-setup.sh` and `password-generator.php` which are added to the image during build
- `env-setup.sh` modifies several files based on their corresponding environment variable
- `password-generator.php` aids in the generation of valid hashed passwords
- Updated README to explain the variables

New environment variables:

| Environment Variable   | Description                                      | Default       |
|------------------------|--------------------------------------------------|---------------|
| RASPAP_SSID            | The SSID name                                    | raspap-webgui |
| RASPAP_SSID_PASS       | The SSID password                                | ChangeMe      |
| RASPAP_COUNTRY         | The SSID country code                            | GB            |
| RASPAP_WEBGUI_USER     | The admin username for the RaspAP user interface | admin         |
| RASPAP_WEBGUI_PASS     | The admin password for the RaspAP user interface | secret        |
| RASPAP_WEBGUI_PORT     | The RaspAP web user interface port               | 80            |

Some further configuration is also possible through the use of the following prefixed environment variables, in the form RASAPAP_\[target]_\[key]

| Environment Variable Prefix | Target File                    |
|-----------------------------|--------------------------------|
| RASPAP_hostapd_             | /etc/hostapd/hostapd.conf      |
| RASPAP_raspap_              | /etc/dnsmasq.d/090_raspap.conf |
| RASPAP_wlan0_               | /etc/dnsmasq.d/090_wlan0.conf  |

For example, `RASPAP_hostapd_driver` would set the `driver` value in `/etc/hostapd/hostapd.conf`
