### PR TITLE
Add container support for RestAPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
 
 VOLUME [ "/sys/fs/cgroup" ]
 
-RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1
+EXPOSE 8081
+
+RUN curl -sL https://install.raspap.com | bash -s -- --yes --wireguard 1 --openvpn 1 --adblock 1 --rest 1
 COPY firewall-rules.sh /home/firewall-rules.sh
 COPY wpa_supplicant.conf /etc/wpa_supplicant/
 RUN chmod +x /home/firewall-rules.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,11 @@ services:
     container_name: raspap
     image: ghcr.io/raspap/raspap-docker:latest
     #build: .
+    ports:
+      - "8081:8081"
     privileged: true
     network_mode: host
-    #cgroup: host # uncomment when using an ARM device 
+    #cgroup: host # uncomment when using an ARM device
     environment:
       - RASPAP_SSID=raspap-webgui
       - RASPAP_SSID_PASS=ChangeMe


### PR DESCRIPTION
Exposes port 8081 for external API access, adds `--rest 1` to auto install API (untested)
See https://github.com/RaspAP/raspap-webgui/pull/1519